### PR TITLE
Allow basic auth username to be explicitly defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Configure env variables:
 ```
 WS_URL - websocket endpoint
 CP_ID - ID of this VCP
+CP_USERNAME - if used for OCPP Authentication, defaults to CP_ID if only PASSWORD defined
 PASSWORD - if used for OCPP Authentication, otherwise can be left blank
 ```
 

--- a/index_16.ts
+++ b/index_16.ts
@@ -8,6 +8,7 @@ const vcp = new VCP({
   endpoint: process.env["WS_URL"] ?? "ws://localhost:3000",
   chargePointId: process.env["CP_ID"] ?? "123456",
   ocppVersion: OcppVersion.OCPP_1_6,
+  basicAuthUsername: process.env["CP_USERNAME"] ?? undefined,
   basicAuthPassword: process.env["PASSWORD"] ?? undefined,
   adminWsPort: parseInt(
     process.env["ADMIN_PORT"] ?? "9999"

--- a/index_201.ts
+++ b/index_201.ts
@@ -8,6 +8,7 @@ const vcp = new VCP({
   endpoint: process.env["WS_URL"] ?? "ws://localhost:3000",
   chargePointId: process.env["CP_ID"] ?? "123456",
   ocppVersion: OcppVersion.OCPP_2_0_1,
+  basicAuthUsername: process.env["CP_USERNAME"] ?? undefined,
   basicAuthPassword: process.env["PASSWORD"] ?? undefined,
   adminWsPort: parseInt(process.env["ADMIN_WS_PORT"] ?? "9999"),
 });

--- a/src/vcp.ts
+++ b/src/vcp.ts
@@ -19,6 +19,7 @@ interface VCPOptions {
   ocppVersion: OcppVersion;
   endpoint: string;
   chargePointId: string;
+  basicAuthUsername?: string;
   basicAuthPassword?: string;
   adminWsPort?: number;
 }
@@ -54,7 +55,7 @@ export class VCP {
       this.ws = new WebSocket(websocketUrl, [protocol], {
         rejectUnauthorized: false,
         auth: this.vcpOptions.basicAuthPassword
-          ? `${this.vcpOptions.chargePointId}:${this.vcpOptions.basicAuthPassword}`
+          ? `${this.vcpOptions.basicAuthUsername || this.vcpOptions.chargePointId}:${this.vcpOptions.basicAuthPassword}`
           : undefined,
         followRedirects: true,
       });


### PR DESCRIPTION
Currently when basic authorization is used because the `PASSWORD` environment variable is defined, the username is assumed to be the charge point ID (the `CP_ID` environment variable). This change is to allow an explicit basic authorization username to be used instead, by defining a `CP_USERNAME` environment variable. For example:

```sh
WS_URL=ws://localhost:9085/ocpp/j/v16 CP_ID=CP0 CP_USERNAME=foo PASSWORD=secret npx ts-node index_16.ts
```
In the case that `PASSWORD` is defined but `CP_USERNAME` is not, then the current behavior is preserved and `CP_ID` is used for the basic authorization username.