### PR TITLE
Fix(): certificate path should not be relative to current directory

### DIFF
--- a/src/ocmfGenerator.ts
+++ b/src/ocmfGenerator.ts
@@ -58,11 +58,14 @@ const generateOCMFData = (input: OCMFInput) => {
 const generateOCMFSignature = (data: string) => {
   const sign = crypto.createSign("sha256");
   sign.update(data);
+  const projectRoot = path.resolve(__dirname, '../');
+  const certPath = path.join(projectRoot, 'cert/vcp.pem');
+
   const signature = sign
-    .sign({
-      key: fs.readFileSync(path.resolve("./cert/vcp.pem"), "utf8"),
-    })
-    .toString("hex");
+      .sign({
+        key: fs.readFileSync(certPath, "utf8"),
+      })
+      .toString("hex");
   return { SA: "ECDSA-secp256k1-SHA256", SD: signature };
 };
 
@@ -73,5 +76,7 @@ export const generateOCMF = (input: OCMFInput) => {
 };
 
 export const getOCMFPublicKey = () => {
-  return fs.readFileSync(path.resolve("./cert/vcp.pub"));
+  const projectRoot = path.resolve(__dirname, '../');
+  const certPath = path.join(projectRoot, 'cert/vcp.pub');
+  return fs.readFileSync(certPath, "utf8");
 };


### PR DESCRIPTION
Whenever I launch the simulator from a folder that is not strictly the root of the simulator project, I get an issue at the end of a charging session, when I try to stop it (and only then):

```
node:fs:563
  return binding.open(
                 ^

Error: ENOENT: no such file or directory, open '/Users/userName/my-current-dir/cert/vcp.pub'
...
```

This proposition of changes fixes the issue.

The alternative would be to instruct clearly on the README to only launch the simulator from its root folder (but I find it not convenient because I use it in a bash script for easing the process of launching it).