### PR TITLE
feat: add VCP terminate method to simualte abrupt CPO disconnects

### DIFF
--- a/src/vcp.ts
+++ b/src/vcp.ts
@@ -176,6 +176,11 @@ export class VCP {
     process.exit(1);
   }
 
+  terminate(): void {
+    this.ws?.terminate();
+    process.exit(1);
+  }
+
   async getDiagnosticData(): Promise<LogEntry[]> {
     try {
       // Get logs from Winston logger's memory


### PR DESCRIPTION
# Overview

Add a `terminate` method to the `VCP` class to abruptly disconnect the underlying WebSocket connection. This is intended to be used instead of the `close` method when we do not want to gracefully disconnect. 

For example, when simulating a power loss scenario where the charge point will temporarily become unavailable.