### PR TITLE
feat: add firmware-status-notification commands

### DIFF
--- a/admin/v16/Firmware/firmware-status-notification.ts
+++ b/admin/v16/Firmware/firmware-status-notification.ts
@@ -1,0 +1,10 @@
+import * as uuid from "uuid";
+import { sendAdminCommand } from "../../admin";
+
+sendAdminCommand({
+  action: "FirmwareStatusNotification",
+  messageId: uuid.v4(),
+  payload: {
+    status: "Installed",
+  },
+});

--- a/admin/v201/Firmware/firmware-status-notification.ts
+++ b/admin/v201/Firmware/firmware-status-notification.ts
@@ -1,0 +1,10 @@
+import * as uuid from "uuid";
+import { sendAdminCommand } from "../../admin";
+
+sendAdminCommand({
+  action: "FirmwareStatusNotification",
+  messageId: uuid.v4(),
+  payload: {
+    status: "Installed",
+  },
+});

--- a/index_201.ts
+++ b/index_201.ts
@@ -10,7 +10,7 @@ const vcp = new VCP({
   chargePointId: process.env.CP_ID ?? "123456",
   ocppVersion: OcppVersion.OCPP_2_0_1,
   basicAuthPassword: process.env.PASSWORD ?? undefined,
-  adminPort: Number.parseInt(process.env.ADMIN_WS_PORT ?? "9999"),
+  adminPort: Number.parseInt(process.env.ADMIN_PORT ?? "9999"),
 });
 
 (async () => {

--- a/index_21.ts
+++ b/index_21.ts
@@ -10,7 +10,7 @@ const vcp = new VCP({
   chargePointId: process.env.CP_ID ?? "123456",
   ocppVersion: OcppVersion.OCPP_2_1,
   basicAuthPassword: process.env.PASSWORD ?? undefined,
-  adminPort: Number.parseInt(process.env.ADMIN_WS_PORT ?? "9999"),
+  adminPort: Number.parseInt(process.env.ADMIN_PORT ?? "9999"),
 });
 
 (async () => {


### PR DESCRIPTION
- Adds the `FirmwareStatusNotification` commands - for both 1.6 and 2.0.1.
- Unifies the `ADMIN_WS_PORT` env variable reference to `ADMIN_PORT` (used by 1.6 and Dockerfile).