### PR TITLE
feat(EPS-1811): weighted chaos mode and session null race fix

### DIFF
--- a/demo/charging.ts
+++ b/demo/charging.ts
@@ -364,19 +364,21 @@ export async function stopChargingSession(
 ): Promise<void> {
   if (!station.session) return;
 
-  // Finalize energy
-  const elapsed = Date.now() - station.session.startedAt;
-  const progress = Math.min(elapsed / station.session.durationMs, 1);
-  station.session.currentEnergyWh =
-    progress * station.session.targetEnergyWh;
+  // Capture session ref before any async work — disconnect can null it mid-await
+  const session = station.session;
 
-  const deliveredKwh = station.session.currentEnergyWh / 1000;
+  // Finalize energy
+  const elapsed = Date.now() - session.startedAt;
+  const progress = Math.min(elapsed / session.durationMs, 1);
+  session.currentEnergyWh = progress * session.targetEnergyWh;
+
+  const deliveredKwh = session.currentEnergyWh / 1000;
   const durationMin = elapsed / 60_000;
 
   // Clear meter timer
-  if (station.session.meterTimer) {
-    clearInterval(station.session.meterTimer);
-    station.session.meterTimer = null;
+  if (session.meterTimer) {
+    clearInterval(session.meterTimer);
+    session.meterTimer = null;
   }
 
   station.state = "finishing";
@@ -388,7 +390,7 @@ export async function stopChargingSession(
   }
 
   // Update base meter
-  station.meterBaseWh += station.session.currentEnergyWh;
+  station.meterBaseWh += session.currentEnergyWh;
 
   // Update stats
   stats.sessionsCompleted++;

--- a/demo/scenarios.ts
+++ b/demo/scenarios.ts
@@ -231,7 +231,30 @@ export function scheduleEnvScenarios(stations: Station[]): void {
 // Chaos mode — random scenarios in a loop
 // ---------------------------------------------------------------------------
 
-const CHAOS_SCENARIOS = SCENARIOS.filter((s) => s.name !== "surge");
+interface WeightedScenario {
+  scenario: Scenario | null;
+  weight: number;
+  label: string;
+}
+
+const CHAOS_WEIGHTED: WeightedScenario[] = [
+  { scenario: null, weight: 25, label: "nothing" },
+  { scenario: SCENARIOS.find((s) => s.name === "peak-hour")!, weight: 20, label: "peak-hour" },
+  { scenario: SCENARIOS.find((s) => s.name === "idle-night")!, weight: 20, label: "idle-night" },
+  { scenario: SCENARIOS.find((s) => s.name === "target-failover")!, weight: 15, label: "target-failover" },
+  { scenario: SCENARIOS.find((s) => s.name === "rolling-restart")!, weight: 10, label: "rolling-restart" },
+  { scenario: SCENARIOS.find((s) => s.name === "blackout")!, weight: 10, label: "blackout" },
+];
+
+function pickWeighted(entries: WeightedScenario[]): WeightedScenario {
+  const total = entries.reduce((sum, e) => sum + e.weight, 0);
+  let roll = Math.random() * total;
+  for (const entry of entries) {
+    roll -= entry.weight;
+    if (roll <= 0) return entry;
+  }
+  return entries[entries.length - 1];
+}
 
 export function startChaosLoop(stations: Station[]): void {
   if (!CONFIG.chaosMode) return;
@@ -240,24 +263,31 @@ export function startChaosLoop(stations: Station[]): void {
     const delay =
       CONFIG.chaosMinIntervalMs +
       Math.random() * (CONFIG.chaosMaxIntervalMs - CONFIG.chaosMinIntervalMs);
-    const pick =
-      CHAOS_SCENARIOS[Math.floor(Math.random() * CHAOS_SCENARIOS.length)];
+    const pick = pickWeighted(CHAOS_WEIGHTED);
 
     setTimeout(() => {
-      pick.execute(stations);
+      if (pick.scenario) {
+        pick.scenario.execute(stations);
+      } else {
+        console.log(
+          `${C.dim}  Chaos: nothing happened this window${C.reset}`,
+        );
+      }
       scheduleNext();
     }, delay);
 
     console.log(
-      `${C.dim}  Chaos: next scenario "${pick.name}" in ${(delay / 1000).toFixed(0)}s${C.reset}`,
+      `${C.dim}  Chaos: next "${pick.label}" in ${(delay / 1000).toFixed(0)}s${C.reset}`,
     );
   };
 
   console.log(
-    `\n${C.bold}${C.magenta}=== CHAOS MODE ACTIVE ===${C.reset}`,
+    `\n${C.bold}${C.magenta}=== CHAOS MODE ACTIVE (weighted) ===${C.reset}`,
   );
+  const summary = CHAOS_WEIGHTED.map((e) => `${e.label}:${e.weight}%`).join(", ");
+  console.log(`${C.dim}  Weights: ${summary}${C.reset}`);
   console.log(
-    `${C.dim}  Random scenarios every ${CONFIG.chaosMinIntervalMs / 1000}-${CONFIG.chaosMaxIntervalMs / 1000}s (excluding surge)${C.reset}\n`,
+    `${C.dim}  Interval: ${CONFIG.chaosMinIntervalMs / 1000}-${CONFIG.chaosMaxIntervalMs / 1000}s${C.reset}\n`,
   );
 
   scheduleNext();


### PR DESCRIPTION
## Summary
- Chaos mode now uses **weighted random selection** instead of uniform distribution: nothing 25%, peak-hour 20%, idle-night 20%, target-failover 15%, rolling-restart 10%, blackout 10%
- Prevents consecutive blackouts from destabilizing long-running demos
- Fix race condition in `stopChargingSession` where disconnect could null the session reference mid-await, causing crashes

## Related PRs
- [base-emobility-ocpp-proxy#EPS-1811](https://github.com/solidstudiosh/base-emobility-ocpp-proxy/tree/feat/EPS-1811-proxy-dashboard-improvements) — proxy API + demo environment
- [base-emobility-ocpp-proxy-frontend#EPS-1811](https://github.com/solidstudiosh/base-emobility-ocpp-proxy-frontend/tree/feat/EPS-1811-proxy-dashboard-improvements) — dashboard virtualization + UX

## Test plan
- [x] Run `STATION_COUNT=2000 CHAOS_MODE=true WS_URL=ws://localhost:3000 npx tsx demo/simulate-network.ts`
- [x] Verify weighted distribution in startup banner shows correct percentages
- [x] Observe "nothing happened" windows appearing (~25% of intervals)
- [x] Confirm no crashes during extended chaos run (30+ min)
- [x] Verify blackouts are rare (~10%) vs previous ~20%

🤖 Generated with [Claude Code](https://claude.com/claude-code)