### PR TITLE
fix: send Authorization header when basicAuthPassword is empty string

### DIFF
--- a/src/vcp.ts
+++ b/src/vcp.ts
@@ -89,7 +89,7 @@ export class VCP {
         rejectUnauthorized: false,
         followRedirects: true,
         headers: {
-          ...(this.vcpOptions.basicAuthPassword && {
+          ...(this.vcpOptions.basicAuthPassword !== undefined && {
             Authorization: `Basic ${Buffer.from(
               `${this.vcpOptions.chargePointId}:${this.vcpOptions.basicAuthPassword}`,
             ).toString("base64")}`,


### PR DESCRIPTION
## Summary
- Fixed a bug where the `Authorization` header was not sent when `basicAuthPassword` was set to an empty string
- Changed the truthy check (`&&`) to an explicit `!== undefined` check so the header is always included when a password is configured

## Test plan
- [ ] Verify that setting `basicAuthPassword` to an empty string sends the `Authorization` header
- [ ] Verify that omitting `basicAuthPassword` (undefined) still skips the header
- [ ] Verify that non-empty passwords continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)