### PR TITLE
feat: resolve token and transactionId placeholders in outgoing messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ CP_ID - ID of this VCP
 PASSWORD - if used for OCPP Authentication, otherwise can be left blank
 ```
 
+Optional:
+
+```
+TOKEN - token this station authorizes with, substituted into admin commands (see below)
+DISABLE_METER_VALUES - set to "true" to stop sending periodic MeterValues for ongoing transactions
+CONNECTORLESS_FLOW_CONNECTOR_ID - connector to use when a RemoteStartTransaction arrives without a connectorId
+```
+
+By default a `RemoteStartTransaction` without a `connectorId` is rejected.
+Setting `CONNECTORLESS_FLOW_CONNECTOR_ID` makes the VCP accept it on that fixed connector instead.
+
 Run OCPP 1.6:
 
 ```bash
@@ -113,6 +124,39 @@ For example usage, see `admin/` folder.
 
 ```bash
 npx tsx admin/v16/Authorize/authorize.ts
+```
+
+### Placeholders in admin commands
+
+The commands in `admin/` are shared across charge points, so they cannot hardcode a station's token or know the id of a transaction that is already running.
+Instead they send placeholders, which the VCP substitutes from its own state just before the message goes out.
+Substitution happens in the VCP process — the admin command only proxies the payload to it — so `TOKEN` belongs in the env file the VCP was started with, not on the admin command:
+
+| Placeholder | Substituted with |
+| --- | --- |
+| token `__TOKEN__` | the `TOKEN` env var |
+| `transactionId` of `0` (or `"0"` in 2.0.1/2.1) | the id of the ongoing transaction |
+
+Both are best-effort and never guess:
+
+- A token other than `__TOKEN__` is sent as-is, so a command that spells out a real token keeps working. If `TOKEN` is not set, the placeholder is sent unchanged — the Central System then rejects a recognisable value instead of the command silently authorizing as someone else.
+- A `transactionId` is only resolved when there is exactly one ongoing transaction. With none, or more than one, the `0` is sent unchanged and the Central System decides how to respond. Set `TRANSACTION_ID` to target a specific transaction.
+
+```bash
+# .env.platform-dev.my-station
+WS_URL=ws://localhost:3000
+CP_ID=my-station
+TOKEN=AABBCCDD
+```
+
+```bash
+# the station is started with that env file...
+npm start platform-dev.my-station index_16.ts
+
+# ...then the same commands work against any station: the transaction starts
+# with that station's TOKEN and stops without its id having to be looked up
+npx tsx admin/v16/Transaction/startTransaction.ts
+npx tsx admin/v16/Transaction/stopTransaction.ts
 ```
 
 ---

--- a/admin/v16/Authorize/authorize.ts
+++ b/admin/v16/Authorize/authorize.ts
@@ -5,6 +5,9 @@ sendAdminCommand({
   action: "Authorize",
   messageId: uuid.v4(),
   payload: {
-    idTag: "AABBCCDD",
+    // "__TOKEN__" is a placeholder: the VCP substitutes the TOKEN env
+    // var, so the token does not have to be edited per station. Spell
+    // out a token here to override it.
+    idTag: "__TOKEN__",
   },
 });

--- a/admin/v16/Transaction/meterValues.ts
+++ b/admin/v16/Transaction/meterValues.ts
@@ -2,7 +2,13 @@ import * as uuid from "uuid";
 import { sendAdminCommand } from "../../admin";
 
 const POWER = Number.parseFloat(process.env.POWER ?? "1");
-const transactionId = Number.parseInt(process.env.TRANSACTION_ID ?? "1");
+// Kept as a string so the value is sent exactly as configured - the schema
+// expects a string and a float round-trip could change the digits.
+const ENERGY = process.env.ENERGY ?? "43.123456789";
+// 0 is a placeholder: the VCP substitutes the id of the ongoing transaction, so
+// it does not have to be known here. Left as 0 if there is no transaction, or
+// more than one - then the CSMS decides how to respond.
+const transactionId = Number.parseInt(process.env.TRANSACTION_ID ?? "0");
 
 sendAdminCommand({
   action: "MeterValues",
@@ -20,7 +26,7 @@ sendAdminCommand({
             unit: "kW",
           },
           {
-            value: "43.123456789",
+            value: ENERGY,
             measurand: "Energy.Active.Import.Register",
             unit: "kWh",
           },

--- a/admin/v16/Transaction/meterValues_PowerActiveImport.ts
+++ b/admin/v16/Transaction/meterValues_PowerActiveImport.ts
@@ -1,7 +1,10 @@
 import * as uuid from "uuid";
 import { sendAdminCommand } from "../../admin";
 
-const transactionId = Number.parseInt(process.env.TRANSACTION_ID ?? "1");
+// 0 is a placeholder: the VCP substitutes the id of the ongoing transaction, so
+// it does not have to be known here. Left as 0 if there is no transaction, or
+// more than one - then the CSMS decides how to respond.
+const transactionId = Number.parseInt(process.env.TRANSACTION_ID ?? "0");
 
 sendAdminCommand({
   action: "MeterValues",

--- a/admin/v16/Transaction/startTransaction-reserved.ts
+++ b/admin/v16/Transaction/startTransaction-reserved.ts
@@ -6,7 +6,10 @@ sendAdminCommand({
   messageId: uuid.v4(),
   payload: {
     connectorId: 1,
-    idTag: "AABBCCDD",
+    // "__TOKEN__" is a placeholder: the VCP substitutes the TOKEN env
+    // var, so the token does not have to be edited per station. Spell
+    // out a token here to override it.
+    idTag: "__TOKEN__",
     meterStart: 0,
     reservationId: 44,
     timestamp: new Date(),

--- a/admin/v16/Transaction/startTransaction.ts
+++ b/admin/v16/Transaction/startTransaction.ts
@@ -6,7 +6,10 @@ sendAdminCommand({
   messageId: uuid.v4(),
   payload: {
     connectorId: 1,
-    idTag: "AABBCCDD",
+    // "__TOKEN__" is a placeholder: the VCP substitutes the TOKEN env
+    // var, so the token does not have to be edited per station. Spell
+    // out a token here to override it.
+    idTag: "__TOKEN__",
     meterStart: 0,
     timestamp: new Date(),
   },

--- a/admin/v16/Transaction/stopTransaction.ts
+++ b/admin/v16/Transaction/stopTransaction.ts
@@ -5,8 +5,11 @@ sendAdminCommand({
   action: "StopTransaction",
   messageId: uuid.v4(),
   payload: {
-    transactionId: 1,
+    // 0 is a placeholder: the VCP substitutes the id of the ongoing
+    // transaction, so it does not have to be known here. Left as 0 if there is
+    // no transaction, or more than one - then the CSMS decides how to respond.
+    transactionId: 0,
     timestamp: new Date(),
-    meterStop: 2000,
+    meterStop: Number.parseInt(process.env.METER_STOP ?? "2000"),
   },
 });

--- a/admin/v201/Authorize/iso14443.ts
+++ b/admin/v201/Authorize/iso14443.ts
@@ -6,7 +6,10 @@ sendAdminCommand({
   messageId: uuid.v4(),
   payload: {
     idToken: {
-      idToken: "AABBCCDD",
+      // "__TOKEN__" is a placeholder: the VCP substitutes the TOKEN env
+      // var, so the token does not have to be edited per station. Spell
+      // out a token here to override it.
+      idToken: "__TOKEN__",
       type: "ISO14443",
     },
   },

--- a/admin/v201/Authorize/iso15693.ts
+++ b/admin/v201/Authorize/iso15693.ts
@@ -6,7 +6,10 @@ sendAdminCommand({
   messageId: uuid.v4(),
   payload: {
     idToken: {
-      idToken: "AABBCCDDEEFF",
+      // "__TOKEN__" is a placeholder: the VCP substitutes the TOKEN env
+      // var, so the token does not have to be edited per station. Spell
+      // out a token here to override it.
+      idToken: "__TOKEN__",
       type: "ISO15693",
     },
   },

--- a/admin/v201/Transaction/startTransaction.ts
+++ b/admin/v201/Transaction/startTransaction.ts
@@ -17,7 +17,10 @@ sendAdminCommand({
       transactionId: transactionId,
     },
     idToken: {
-      idToken: "AABBCCDD",
+      // "__TOKEN__" is a placeholder: the VCP substitutes the TOKEN env
+      // var, so the token does not have to be edited per station. Spell
+      // out a token here to override it.
+      idToken: "__TOKEN__",
       type: "ISO14443",
     },
     meterValue: [

--- a/admin/v201/Transaction/stopTransaction.ts
+++ b/admin/v201/Transaction/stopTransaction.ts
@@ -2,7 +2,10 @@ import * as uuid from "uuid";
 import { sendAdminCommand } from "../../admin";
 
 const date = new Date();
-const transactionId = process.env.TRANSACTION_ID ?? uuid.v4();
+// "0" is a placeholder: the VCP substitutes the id of the ongoing transaction,
+// so it does not have to be known here. Left as "0" if there is no transaction,
+// or more than one - then the CSMS decides how to respond.
+const transactionId = process.env.TRANSACTION_ID ?? "0";
 
 sendAdminCommand({
   action: "TransactionEvent",
@@ -17,7 +20,8 @@ sendAdminCommand({
     },
     evse: { id: 1 },
     idToken: {
-      idToken: "AABBCCDD",
+      // Substituted from the TOKEN env var - see startTransaction.
+      idToken: "__TOKEN__",
       type: "ISO14443",
     },
     meterValue: [

--- a/admin/v201/Transaction/updateTransaction.ts
+++ b/admin/v201/Transaction/updateTransaction.ts
@@ -2,7 +2,10 @@ import * as uuid from "uuid";
 import { sendAdminCommand } from "../../admin";
 
 const date = new Date();
-const transactionId = process.env.TRANSACTION_ID ?? uuid.v4();
+// "0" is a placeholder: the VCP substitutes the id of the ongoing transaction,
+// so it does not have to be known here. Left as "0" if there is no transaction,
+// or more than one - then the CSMS decides how to respond.
+const transactionId = process.env.TRANSACTION_ID ?? "0";
 
 sendAdminCommand({
   action: "TransactionEvent",

--- a/src/ocppMessage.ts
+++ b/src/ocppMessage.ts
@@ -92,6 +92,16 @@ export abstract class OcppOutgoing<
     _result: OcppCallResult<z.infer<ResSchema>>,
   ) => Promise<void>;
 
+  /**
+   * Optional last-moment rewrite of an outgoing payload, applied by
+   * `VCP.send()` before the call is enqueued in the outbox and serialized.
+   * Lets a message fill in values that the caller (e.g. an admin command)
+   * cannot know, based on current VCP state. Return the payload unchanged to
+   * opt out.
+   */
+  beforeSend?: (vcp: VCP, payload: z.infer<ReqSchema>) => z.infer<ReqSchema> =
+    undefined;
+
   request = (payload: z.infer<ReqSchema>): OcppCall<z.infer<ReqSchema>> => {
     return call(this.action, this.parseRequestPayload(payload));
   };

--- a/src/schemaValidator.ts
+++ b/src/schemaValidator.ts
@@ -28,7 +28,7 @@ const getOcppIncomingMessages = (ocppVersion: OcppVersion) => {
   }
 };
 
-const getOcppOutgoingMessages = (ocppVersion: OcppVersion) => {
+export const getOcppOutgoingMessages = (ocppVersion: OcppVersion) => {
   switch (ocppVersion) {
     case OcppVersion.OCPP_1_6:
       return ocppOutgoingMessages16;

--- a/src/tokenPlaceholder.ts
+++ b/src/tokenPlaceholder.ts
@@ -1,0 +1,19 @@
+/**
+ * Admin commands are shared across charge points, but the token to authorize
+ * with differs per station and is configured per env file as TOKEN. To avoid
+ * editing the commands for every station, they send this placeholder as the
+ * token and the matching `beforeSend` hook substitutes TOKEN before sending.
+ *
+ * A token other than the placeholder is always sent as-is, so a command that
+ * spells out a real token keeps working. The placeholder is also left as-is
+ * when TOKEN is not set - the CSMS then rejects a recognisable value rather
+ * than the command silently authorizing as someone else.
+ */
+export const TOKEN_PLACEHOLDER = "__TOKEN__";
+
+export const resolveTokenPlaceholder = (token: string): string => {
+  if (token !== TOKEN_PLACEHOLDER) {
+    return token;
+  }
+  return process.env.TOKEN ?? token;
+};

--- a/src/transactionManager.ts
+++ b/src/transactionManager.ts
@@ -2,6 +2,11 @@ import type { VCP } from "./vcp";
 
 const METER_VALUES_INTERVAL_SEC = 15;
 
+// Periodic MeterValues are sent for every ongoing transaction. Set
+// DISABLE_METER_VALUES=true to stop sending them - useful when they only add
+// noise, or when the values are driven by admin commands instead.
+const METER_VALUES_DISABLED = process.env.DISABLE_METER_VALUES === "true";
+
 type TransactionId = string | number;
 
 interface TransactionState {
@@ -24,7 +29,7 @@ interface StartTransactionProps {
 export class TransactionManager {
   transactions: Map<
     TransactionId,
-    TransactionState & { meterValuesTimer: ReturnType<typeof setInterval> }
+    TransactionState & { meterValuesTimer?: ReturnType<typeof setInterval> }
   > = new Map();
 
   canStartNewTransaction(connectorId: number) {
@@ -34,18 +39,22 @@ export class TransactionManager {
   }
 
   startTransaction(vcp: VCP, startTransactionProps: StartTransactionProps) {
-    const meterValuesTimer = setInterval(() => {
-      // biome-ignore lint/style/noNonNullAssertion: transaction must exist
-      const currentTransactionState = this.transactions.get(
-        startTransactionProps.transactionId,
-      )!;
-      const { meterValuesTimer, ...currentTransaction } =
-        currentTransactionState;
-      startTransactionProps.meterValuesCallback({
-        ...currentTransaction,
-        meterValue: this.getMeterValue(startTransactionProps.transactionId),
-      });
-    }, METER_VALUES_INTERVAL_SEC * 1000);
+    // No timer at all when disabled, rather than one that wakes up to do
+    // nothing.
+    const meterValuesTimer = METER_VALUES_DISABLED
+      ? undefined
+      : setInterval(() => {
+          // biome-ignore lint/style/noNonNullAssertion: transaction must exist
+          const currentTransactionState = this.transactions.get(
+            startTransactionProps.transactionId,
+          )!;
+          const { meterValuesTimer, ...currentTransaction } =
+            currentTransactionState;
+          startTransactionProps.meterValuesCallback({
+            ...currentTransaction,
+            meterValue: this.getMeterValue(startTransactionProps.transactionId),
+          });
+        }, METER_VALUES_INTERVAL_SEC * 1000);
     this.transactions.set(startTransactionProps.transactionId, {
       transactionId: startTransactionProps.transactionId,
       idTag: startTransactionProps.idTag,
@@ -55,6 +64,17 @@ export class TransactionManager {
       connectorId: startTransactionProps.connectorId,
       meterValuesTimer: meterValuesTimer,
     });
+  }
+
+  /**
+   * The id of the only ongoing transaction, or undefined when there is no
+   * transaction or more than one - i.e. when it would be ambiguous.
+   */
+  onlyTransactionId(): TransactionId | undefined {
+    if (this.transactions.size !== 1) {
+      return undefined;
+    }
+    return this.transactions.keys().next().value;
   }
 
   stopTransaction(transactionId: TransactionId) {

--- a/src/v16/messages/authorize.ts
+++ b/src/v16/messages/authorize.ts
@@ -4,6 +4,7 @@ import {
   type OcppCallResult,
   OcppOutgoing,
 } from "../../ocppMessage";
+import { resolveTokenPlaceholder } from "../../tokenPlaceholder";
 import type { VCP } from "../../vcp";
 import { IdTagInfoSchema } from "./_common";
 
@@ -21,6 +22,13 @@ class AuthorizeOcppMessage extends OcppOutgoing<
   AuthorizeReqType,
   AuthorizeResType
 > {
+  beforeSend = (
+    _vcp: VCP,
+    payload: z.infer<AuthorizeReqType>,
+  ): z.infer<AuthorizeReqType> => {
+    return { ...payload, idTag: resolveTokenPlaceholder(payload.idTag) };
+  };
+
   resHandler = async (
     _vcp: VCP,
     _call: OcppCall<z.infer<AuthorizeReqType>>,

--- a/src/v16/messages/meterValues.ts
+++ b/src/v16/messages/meterValues.ts
@@ -21,6 +21,23 @@ class MeterValuesOcppMessage extends OcppOutgoing<
   MeterValuesReqType,
   MeterValuesResType
 > {
+  // Callers that cannot know the transactionId assigned by StartTransaction
+  // (e.g. admin commands) may send 0 as a placeholder - resolve it as long as
+  // there is exactly one ongoing transaction to resolve it to.
+  beforeSend = (
+    vcp: VCP,
+    payload: z.infer<MeterValuesReqType>,
+  ): z.infer<MeterValuesReqType> => {
+    if (payload.transactionId !== 0) {
+      return payload;
+    }
+    const transactionId = vcp.transactionManager.onlyTransactionId();
+    if (transactionId === undefined) {
+      return payload;
+    }
+    return { ...payload, transactionId: Number(transactionId) };
+  };
+
   resHandler = async (
     _vcp: VCP,
     _call: OcppCall<z.infer<MeterValuesReqType>>,

--- a/src/v16/messages/remoteStartTransaction.ts
+++ b/src/v16/messages/remoteStartTransaction.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { logger } from "../../logger";
 import { type OcppCall, OcppIncoming } from "../../ocppMessage";
 import type { VCP } from "../../vcp";
 import {
@@ -30,12 +31,27 @@ class RemoteStartTransactionOcppMessage extends OcppIncoming<
     call: OcppCall<z.infer<RemoteStartTransactionReqType>>,
   ): Promise<void> => {
     if (!call.payload.connectorId) {
-      vcp.respond(this.response(call, { status: "Rejected" }));
-      return;
+      if (process.env.CONNECTORLESS_FLOW_CONNECTOR_ID) {
+        call.payload.connectorId = Number(
+          process.env.CONNECTORLESS_FLOW_CONNECTOR_ID,
+        );
+        logger.info(
+          `RemoteStartTransaction has no connectorId - using the preconfigured CONNECTORLESS_FLOW_CONNECTOR_ID=${call.payload.connectorId}`,
+        );
+      } else {
+        logger.warn(
+          "Rejecting RemoteStartTransaction: no connectorId in the request. Set CONNECTORLESS_FLOW_CONNECTOR_ID to accept it on a fixed connector.",
+        );
+        vcp.respond(this.response(call, { status: "Rejected" }));
+        return;
+      }
     }
     if (
       !vcp.transactionManager.canStartNewTransaction(call.payload.connectorId)
     ) {
+      logger.warn(
+        `Rejecting RemoteStartTransaction: connector ${call.payload.connectorId} already has an ongoing transaction.`,
+      );
       vcp.respond(this.response(call, { status: "Rejected" }));
       return;
     }

--- a/src/v16/messages/startTransaction.ts
+++ b/src/v16/messages/startTransaction.ts
@@ -4,6 +4,7 @@ import {
   type OcppCallResult,
   OcppOutgoing,
 } from "../../ocppMessage";
+import { resolveTokenPlaceholder } from "../../tokenPlaceholder";
 import type { VCP } from "../../vcp";
 import { ConnectorIdSchema, IdTagInfoSchema, IdTokenSchema } from "./_common";
 import { meterValuesOcppMessage } from "./meterValues";
@@ -29,6 +30,13 @@ class StartTransactionOcppMessage extends OcppOutgoing<
   StartTransactionReqType,
   StartTransactionResType
 > {
+  beforeSend = (
+    _vcp: VCP,
+    payload: z.infer<StartTransactionReqType>,
+  ): z.infer<StartTransactionReqType> => {
+    return { ...payload, idTag: resolveTokenPlaceholder(payload.idTag) };
+  };
+
   resHandler = async (
     vcp: VCP,
     call: OcppCall<z.infer<StartTransactionReqType>>,

--- a/src/v16/messages/stopTransaction.ts
+++ b/src/v16/messages/stopTransaction.ts
@@ -40,6 +40,23 @@ class StopTransactionOcppMessage extends OcppOutgoing<
   StopTransactionReqType,
   StopTransactionResType
 > {
+  // Callers that cannot know the transactionId assigned by StartTransaction
+  // (e.g. admin commands) may send 0 as a placeholder - resolve it as long as
+  // there is exactly one ongoing transaction to resolve it to.
+  beforeSend = (
+    vcp: VCP,
+    payload: z.infer<StopTransactionReqType>,
+  ): z.infer<StopTransactionReqType> => {
+    if (payload?.transactionId !== 0) {
+      return payload;
+    }
+    const transactionId = vcp.transactionManager.onlyTransactionId();
+    if (transactionId === undefined) {
+      return payload;
+    }
+    return { ...payload, transactionId: Number(transactionId) };
+  };
+
   resHandler = async (
     vcp: VCP,
     call: OcppCall<z.infer<StopTransactionReqType>>,

--- a/src/v201/messages/authorize.ts
+++ b/src/v201/messages/authorize.ts
@@ -4,6 +4,7 @@ import {
   type OcppCallResult,
   OcppOutgoing,
 } from "../../ocppMessage";
+import { resolveTokenPlaceholder } from "../../tokenPlaceholder";
 import type { VCP } from "../../vcp";
 import {
   IdTokenInfoTypeSchema,
@@ -41,6 +42,19 @@ class AuthorizeOcppOutgoing extends OcppOutgoing<
   AuthorizeReqType,
   AuthorizeResType
 > {
+  beforeSend = (
+    _vcp: VCP,
+    payload: z.infer<AuthorizeReqType>,
+  ): z.infer<AuthorizeReqType> => {
+    return {
+      ...payload,
+      idToken: {
+        ...payload.idToken,
+        idToken: resolveTokenPlaceholder(payload.idToken.idToken),
+      },
+    };
+  };
+
   resHandler = async (
     _vcp: VCP,
     _call: OcppCall<z.infer<AuthorizeReqType>>,

--- a/src/v201/messages/transactionEvent.ts
+++ b/src/v201/messages/transactionEvent.ts
@@ -4,6 +4,7 @@ import {
   type OcppCallResult,
   OcppOutgoing,
 } from "../../ocppMessage";
+import { resolveTokenPlaceholder } from "../../tokenPlaceholder";
 import type { VCP } from "../../vcp";
 import {
   EVSETypeSchema,
@@ -93,6 +94,42 @@ class TransactionEventOcppOutgoing extends OcppOutgoing<
   TransactionEventReqType,
   TransactionEventResType
 > {
+  beforeSend = (
+    vcp: VCP,
+    payload: z.infer<TransactionEventReqType>,
+  ): z.infer<TransactionEventReqType> => {
+    let resolved = payload;
+    if (resolved.idToken) {
+      resolved = {
+        ...resolved,
+        idToken: {
+          ...resolved.idToken,
+          idToken: resolveTokenPlaceholder(resolved.idToken.idToken),
+        },
+      };
+    }
+    // Callers that cannot know the transactionId of the ongoing transaction
+    // (e.g. admin commands) may send "0" as a placeholder when updating or
+    // ending it - resolve it as long as there is exactly one transaction to
+    // resolve it to. Not for "Started", which is what assigns the id.
+    if (
+      resolved.eventType !== "Started" &&
+      resolved.transactionInfo?.transactionId === "0"
+    ) {
+      const transactionId = vcp.transactionManager.onlyTransactionId();
+      if (transactionId !== undefined) {
+        resolved = {
+          ...resolved,
+          transactionInfo: {
+            ...resolved.transactionInfo,
+            transactionId: String(transactionId),
+          },
+        };
+      }
+    }
+    return resolved;
+  };
+
   resHandler = async (
     _vcp: VCP,
     _call: OcppCall<z.infer<TransactionEventReqType>>,

--- a/src/v21/messages/authorize.ts
+++ b/src/v21/messages/authorize.ts
@@ -4,6 +4,7 @@ import {
   type OcppCallResult,
   OcppOutgoing,
 } from "../../ocppMessage";
+import { resolveTokenPlaceholder } from "../../tokenPlaceholder";
 import type { VCP } from "../../vcp";
 import {
   EnergyTransferMode,
@@ -45,6 +46,19 @@ class AuthorizeOcppOutgoing extends OcppOutgoing<
   AuthorizeReqType,
   AuthorizeResType
 > {
+  beforeSend = (
+    _vcp: VCP,
+    payload: z.infer<AuthorizeReqType>,
+  ): z.infer<AuthorizeReqType> => {
+    return {
+      ...payload,
+      idToken: {
+        ...payload.idToken,
+        idToken: resolveTokenPlaceholder(payload.idToken.idToken),
+      },
+    };
+  };
+
   resHandler = async (
     _vcp: VCP,
     _call: OcppCall<z.infer<AuthorizeReqType>>,

--- a/src/v21/messages/transactionEvent.ts
+++ b/src/v21/messages/transactionEvent.ts
@@ -4,6 +4,7 @@ import {
   type OcppCallResult,
   OcppOutgoing,
 } from "../../ocppMessage";
+import { resolveTokenPlaceholder } from "../../tokenPlaceholder";
 import type { VCP } from "../../vcp";
 import {
   EVSETypeSchema,
@@ -178,6 +179,42 @@ class TransactionEventOcppOutgoing extends OcppOutgoing<
   TransactionEventReqType,
   TransactionEventResType
 > {
+  beforeSend = (
+    vcp: VCP,
+    payload: z.infer<TransactionEventReqType>,
+  ): z.infer<TransactionEventReqType> => {
+    let resolved = payload;
+    if (resolved.idToken) {
+      resolved = {
+        ...resolved,
+        idToken: {
+          ...resolved.idToken,
+          idToken: resolveTokenPlaceholder(resolved.idToken.idToken),
+        },
+      };
+    }
+    // Callers that cannot know the transactionId of the ongoing transaction
+    // (e.g. admin commands) may send "0" as a placeholder when updating or
+    // ending it - resolve it as long as there is exactly one transaction to
+    // resolve it to. Not for "Started", which is what assigns the id.
+    if (
+      resolved.eventType !== "Started" &&
+      resolved.transactionInfo?.transactionId === "0"
+    ) {
+      const transactionId = vcp.transactionManager.onlyTransactionId();
+      if (transactionId !== undefined) {
+        resolved = {
+          ...resolved,
+          transactionInfo: {
+            ...resolved.transactionInfo,
+            transactionId: String(transactionId),
+          },
+        };
+      }
+    }
+    return resolved;
+  };
+
   resHandler = async (
     _vcp: VCP,
     _call: OcppCall<z.infer<TransactionEventReqType>>,

--- a/src/vcp.ts
+++ b/src/vcp.ts
@@ -15,6 +15,7 @@ import {
 import { ocppOutbox } from "./ocppOutbox";
 import { type OcppVersion, toProtocolVersion } from "./ocppVersion";
 import {
+  getOcppOutgoingMessages,
   validateOcppIncomingRequest,
   validateOcppIncomingResponse,
   validateOcppOutgoingRequest,
@@ -121,18 +122,26 @@ export class VCP {
     if (!this.ws) {
       throw new Error("Websocket not initialized. Call connect() first");
     }
-    ocppOutbox.enqueue(ocppCall);
+    // Applied before enqueueing so the outbox holds exactly what went out on
+    // the wire - resHandlers read the payload back from there.
+    const beforeSend = getOcppOutgoingMessages(this.vcpOptions.ocppVersion)[
+      ocppCall.action
+    ]?.beforeSend;
+    const resolvedCall = beforeSend
+      ? { ...ocppCall, payload: beforeSend(this, ocppCall.payload) }
+      : ocppCall;
+    ocppOutbox.enqueue(resolvedCall);
     const jsonMessage = JSON.stringify([
       2,
-      ocppCall.messageId,
-      ocppCall.action,
-      ocppCall.payload,
+      resolvedCall.messageId,
+      resolvedCall.action,
+      resolvedCall.payload,
     ]);
     logger.info(`Sending message ➡️  ${jsonMessage}`);
     validateOcppOutgoingRequest(
       this.vcpOptions.ocppVersion,
-      ocppCall.action,
-      JSON.parse(JSON.stringify(ocppCall.payload)),
+      resolvedCall.action,
+      JSON.parse(JSON.stringify(resolvedCall.payload)),
     );
     this.ws.send(jsonMessage);
   }


### PR DESCRIPTION
## Summary

Admin commands are shared across charge points, so they can't hardcode a station's token or know the id of an ongoing transaction. This adds a `beforeSend` hook on outgoing messages — applied by `VCP.send()` before the call is enqueued in the outbox, so the outbox holds exactly what went on the wire — and uses it to substitute placeholders from current VCP state.

**Placeholders**
- `__TOKEN__` → the `TOKEN` env var. v16 `Authorize` / `StartTransaction`, v201+v21 `Authorize` / `TransactionEvent`. Any other token is sent as-is, and the placeholder is left alone when `TOKEN` is unset, so the CSMS rejects a recognisable value rather than the command silently authorizing as someone else.
- transactionId `0` / `"0"` → the id of the only ongoing transaction, and only when that's unambiguous (exactly one). v16 `MeterValues` / `StopTransaction`, v201+v21 `TransactionEvent` for non-`Started` events.

Admin commands updated to send the placeholders instead of `AABBCCDD` / `1`.

**Also**
- `DISABLE_METER_VALUES=true` skips the periodic MeterValues timer entirely (no timer created, rather than one waking up to do nothing).
- `CONNECTORLESS_FLOW_CONNECTOR_ID` lets a `RemoteStartTransaction` with no connectorId be accepted on a fixed connector instead of being rejected; both rejection paths now log why.
- `ENERGY` and `METER_STOP` env overrides in the v16 admin commands.

## Test plan
- [ ] v16: `StartTransaction` / `MeterValues` / `StopTransaction` admin commands against a CSMS with `TOKEN` set — token substituted, transactionId resolved without `TRANSACTION_ID`
- [ ] v201/v21: `Authorize`, start/update/stop `TransactionEvent` equivalents
- [ ] Placeholder left intact (and rejected by CSMS) with `TOKEN` unset
- [ ] `DISABLE_METER_VALUES=true` — no periodic MeterValues
- [ ] `RemoteStartTransaction` without connectorId — accepted with `CONNECTORLESS_FLOW_CONNECTOR_ID` set, rejected with a log line without it

🤖 Generated with [Claude Code](https://claude.com/claude-code)